### PR TITLE
fix: point CODEOWNERS at the real @vedika-io/core-team team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,16 +2,15 @@
 # Requested for review on every PR, and required by the protect-main ruleset's
 # "Require review from Code Owners" rule.
 #
-# NOTE: @vedika-io/maintainers must be a real team in the vedika-io org with
-# write access, OR replace it with a personal maintainer handle (e.g. @your-user).
-# An unresolvable owner here silently disables the code-owner review requirement.
+# @vedika-io/core-team must keep write access to this repo; an unresolvable
+# owner here silently disables the code-owner review requirement.
 
-*                         @vedika-io/maintainers
+*                         @vedika-io/core-team
 
 # Accuracy- and physics-critical paths — these carry the public accuracy claims.
-/crates/xalen-ephem/      @vedika-io/maintainers
-/crates/xalen-coords/     @vedika-io/maintainers
-/crates/xalen-houses/     @vedika-io/maintainers
-/crates/xalen-ayanamsa/   @vedika-io/maintainers
-/docs/ACCURACY.md         @vedika-io/maintainers
-/CHANGELOG.md             @vedika-io/maintainers
+/crates/xalen-ephem/      @vedika-io/core-team
+/crates/xalen-coords/     @vedika-io/core-team
+/crates/xalen-houses/     @vedika-io/core-team
+/crates/xalen-ayanamsa/   @vedika-io/core-team
+/docs/ACCURACY.md         @vedika-io/core-team
+/CHANGELOG.md             @vedika-io/core-team


### PR DESCRIPTION
## What
Repoints every `.github/CODEOWNERS` entry from `@vedika-io/maintainers` to `@vedika-io/core-team`.

## Why
`@vedika-io/maintainers` does not exist in the org (only `core-team` and `interns` do). Because the `protect-main` ruleset has **Require review from Code Owners** enabled, an unresolvable owner **silently disabled** code-owner review on PRs. Pointing at `@vedika-io/core-team` (the team with write access) restores it.

## Scope
Governance file only — no code, no behavior change. CI (`test` gate) runs to confirm.