### PR TITLE
docs: use the xalen.io domain instead of xalen.ai

### DIFF
--- a/ENTERPRISE.md
+++ b/ENTERPRISE.md
@@ -53,8 +53,8 @@ your deployment — get in touch and we'll put together a proposal.
 
 ## Get in touch
 
-- **Email:** hello@xalen.ai
-- **Web:** https://xalen.ai
+- **Email:** hello@xalen.io
+- **Web:** https://xalen.io
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Licensed under the [Apache License, Version 2.0](LICENSE).
 Copyright 2024-2026 XALEN Technology Pvt Ltd.
 ```
 
-For commercial licensing inquiries, contact [hello@xalen.ai](mailto:hello@xalen.ai).
+For commercial licensing inquiries, contact [hello@xalen.io](mailto:hello@xalen.io).
 
 ---
 
@@ -306,7 +306,7 @@ For commercial licensing inquiries, contact [hello@xalen.ai](mailto:hello@xalen.
 XALEN Ephemeris is free and open source (Apache-2.0) — and always will be. For
 production use that needs an **SLA, IP indemnification, a managed/hosted API,
 certified-accuracy reports, white-label, or on-premise support**, see
-**[ENTERPRISE.md](ENTERPRISE.md)** or reach us at **hello@xalen.ai**. The
+**[ENTERPRISE.md](ENTERPRISE.md)** or reach us at **hello@xalen.io**. The
 open-source core stays Apache-2.0; Enterprise only adds services and optional
 proprietary modules on top.
 


### PR DESCRIPTION
Fixes the wrong-TLD domain references: `xalen.ai` → `xalen.io` in `ENTERPRISE.md` (contact email + web) and `README.md` (commercial-licensing + Enterprise contact). Docs-only, no code.

Closes #12