### PR TITLE
fix(deps): bump pyo3 0.28 → 0.29 (RUSTSEC-2026-0176/0177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- Bump `pyo3` from 0.28 to **0.29** in the Python binding to clear
+  RUSTSEC-2026-0176 and RUSTSEC-2026-0177 (fixed in pyo3 ≥ 0.29.0). Migrated the
+  two deprecated `Bound::downcast` calls to `Bound::cast` (pyo3 0.29 API).
+
 ## [0.6.0] - 2026-06-02
 
 This entry consolidates Wave B (accuracy / breadth) and Wave C (bindings parity +

--- a/crates/xalen-python/Cargo.toml
+++ b/crates/xalen-python/Cargo.toml
@@ -29,7 +29,7 @@ doctest = false
 # later 3.x — instead of one wheel per interpreter minor version. This binding
 # only uses the stable-ABI subset (PyDict / PyList / PyAny via the Bound API),
 # so abi3 is sound here.
-pyo3 = { version = "0.28", features = ["abi3-py38"] }
+pyo3 = { version = "0.29", features = ["abi3-py38"] }
 xalen-ephem = { version = "0.6.0", path = "../xalen-ephem" }
 xalen-time = { version = "0.6.0", path = "../xalen-time" }
 xalen-ayanamsa = { version = "0.6.0", path = "../xalen-ayanamsa" }

--- a/crates/xalen-python/src/swe_compat.rs
+++ b/crates/xalen-python/src/swe_compat.rs
@@ -102,7 +102,7 @@ fn calc(jd_et: f64, ipl: i32, flags: i32) -> PyResult<([f64; 6], i32)> {
 /// idiomatic bytes form. A 1-byte/1-char value is required, matching Swiss.
 fn parse_hsys(hsys: &Bound<'_, PyAny>) -> PyResult<char> {
     // bytes (the pyswisseph-native form, e.g. b'P')
-    if let Ok(b) = hsys.downcast::<PyBytes>() {
+    if let Ok(b) = hsys.cast::<PyBytes>() {
         let bytes = b.as_bytes();
         return match bytes.first() {
             Some(&byte) => Ok(byte as char),
@@ -112,7 +112,7 @@ fn parse_hsys(hsys: &Bound<'_, PyAny>) -> PyResult<char> {
         };
     }
     // str (e.g. 'P')
-    if let Ok(s) = hsys.downcast::<PyString>() {
+    if let Ok(s) = hsys.cast::<PyString>() {
         let text: String = s.extract()?;
         return text.chars().next().ok_or_else(|| {
             pyo3::exceptions::PyValueError::new_err(

--- a/validation/src/de440_bench.rs
+++ b/validation/src/de440_bench.rs
@@ -217,7 +217,10 @@ fn main() {
             "metric      : |Δ apparent geocentric ecliptic longitude| (DE440 − VSOP87), arcsec"
         );
     } else {
-        println!("reference   : SELF-BASELINE (no kernel found at {})", cfg.kernel);
+        println!(
+            "reference   : SELF-BASELINE (no kernel found at {})",
+            cfg.kernel
+        );
         println!("candidate   : XALEN analytic VSOP87/ELP series (vs itself)");
         println!(
             "metric      : |Δ longitude| — ~0 by construction; this is a wiring check, NOT a validation"
@@ -247,7 +250,9 @@ fn main() {
     println!();
 
     // Sweep.
-    let mut devs: Vec<Deviation> = (0..BENCH_BODIES.len()).map(|_| Deviation::default()).collect();
+    let mut devs: Vec<Deviation> = (0..BENCH_BODIES.len())
+        .map(|_| Deviation::default())
+        .collect();
     let mut skipped: u64 = 0;
     for &jd in &epochs {
         let jd_ut1 = JdUT1(jd);


### PR DESCRIPTION
## What
Bump `pyo3` from 0.28 to **0.29** in the Python binding to clear two RustSec advisories.

## Why
`cargo audit` flags `pyo3 0.28.3`:
- [RUSTSEC-2026-0176](https://rustsec.org/advisories/RUSTSEC-2026-0176)
- [RUSTSEC-2026-0177](https://rustsec.org/advisories/RUSTSEC-2026-0177)

Both are fixed in `pyo3 >= 0.29.0`. (This is the `Security audit (RustSec)` CI failure currently red on `main`.)

## How
- `crates/xalen-python/Cargo.toml`: `pyo3 = "0.28"` → `"0.29"` (keeps `abi3-py38`).
- `crates/xalen-python/src/swe_compat.rs`: migrate the two deprecated `Bound::downcast::<T>()` calls to `Bound::cast::<T>()` (pyo3 0.29 deprecated `downcast` in favour of `cast`; same `Ok/Err` semantics, so `parse_hsys` behaves identically).

## Verification
- `cargo check -p xalen-python` passes.
- abi3 wheel wiring unchanged (`extension-module`, `abi3-py38`, `pyproject.toml`).
- pyo3 is only used by `xalen-python` (node uses napi, wasm uses wasm-bindgen) — no other crate needs the bump.
- Reviewed by an independent model (Codex), two passes (API correctness + runtime/ABI), both clean.

No functional change to the Python API.
