### PR TITLE
docs: pricing/licensing hardening + reproducible DE440 precision benchmark

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,76 @@
+# XALEN Ephemeris — Contributor License Agreement (v1.0)
+
+Thank you for contributing to XALEN Ephemeris ("the Project"), maintained by
+**XALEN Technology Pvt Ltd** ("XALEN"). This Contributor License Agreement
+("CLA") clarifies the intellectual-property license granted with Contributions
+from any person or entity. It protects you as a contributor as well as XALEN
+and the Project's users; it does not change your rights to use your own
+Contributions for any other purpose.
+
+The Project is dual-licensed (Apache-2.0 and a commercial license). For that
+model to remain possible, XALEN must hold the right to distribute every merged
+Contribution under both licenses — which is what this CLA grants. **You keep
+the copyright in your Contribution.**
+
+## 1. Definitions
+
+- **"You"** means the individual or legal entity agreeing to this CLA. For
+  legal entities, the entity making a Contribution and all other entities that
+  control, are controlled by, or are under common control with that entity are
+  considered a single Contributor.
+- **"Contribution"** means any original work of authorship, including any
+  modifications or additions to an existing work, that You intentionally
+  submit to the Project for inclusion (via pull request, patch, issue, or
+  otherwise).
+
+## 2. Grant of copyright license
+
+You grant XALEN and recipients of software distributed by XALEN a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright
+license to reproduce, prepare derivative works of, publicly display, publicly
+perform, **sublicense** (including under the Project's commercial license),
+and distribute Your Contributions and such derivative works.
+
+## 3. Grant of patent license
+
+You grant XALEN and recipients of software distributed by XALEN a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as
+stated below) patent license to make, have made, use, offer to sell, sell,
+import, and otherwise transfer Your Contribution alone or in combination with
+the work it was submitted to, where such license applies only to patent claims
+licensable by You that are necessarily infringed by Your Contribution alone or
+in combination with that work. If any entity institutes patent litigation
+alleging that Your Contribution or the work infringes a patent, any patent
+licenses granted to that entity under this CLA for that Contribution or work
+terminate as of the date such litigation is filed.
+
+## 4. Your representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses. If Your employer has
+   rights to intellectual property You create, You have received permission to
+   make the Contribution on behalf of that employer, or Your employer has
+   waived such rights.
+2. Each Contribution is Your original creation. Where it includes third-party
+   material, You have identified it, together with its license and any
+   restrictions, in the submission.
+3. You will notify the Project if any of the above becomes inaccurate.
+
+## 5. No warranty / no support obligation
+
+Contributions are provided "AS IS", without warranties or conditions of any
+kind. You are not expected to provide support for Your Contribution.
+
+## 6. How to sign
+
+Until an automated CLA check is enabled on this repository, sign by posting
+the following comment on your first pull request, from the GitHub account
+making the Contribution:
+
+> I have read the CLA at CLA.md and I hereby sign the CLA.
+> Full name: `<your full legal name>` · Email: `<your email>`
+
+A maintainer will record the agreement on the pull request before merge.
+Corporate contributors: have an authorized signatory email the signed
+agreement to **hello@xalen.io** naming the covered GitHub accounts.

--- a/COMMERCIAL_LICENSE.md
+++ b/COMMERCIAL_LICENSE.md
@@ -30,6 +30,36 @@ grant:
 | Enterprise | $2,499/yr | Professional + warranty, IP indemnification, priority fixes, quarterly review calls |
 | OEM | $9,999/yr | Enterprise + white-label terms, custom builds |
 
+## Premium Modules (proprietary add-ons)
+
+Beyond the open-source engine, XALEN offers **closed premium modules** —
+delivered privately to licensees under a signed license, never published to
+public registries:
+
+- **Premium Charts pack** — advanced and specialty chart rendering beyond the
+  open-source SVG set.
+- **Interpretation Content packs** — original, professionally authored
+  interpretation text (remedies, meanings, degree symbolism, midpoint keys)
+  that plugs into the engine's content slots. The open-source engine ships the
+  frameworks; the text is a licensed product.
+- **Precision Data pack** — curated star catalogs, golden reference vectors,
+  and signed accuracy artifacts for regulated or accuracy-audited deployments.
+- **Validation programme** — the "XALEN Validated" mark for builds that pass
+  the published test-vector suite (see [TRADEMARK.md](TRADEMARK.md)).
+
+Premium modules are licensed per deployment and priced by scope — contact us
+for a proposal. Licenses are offline-verifiable (signed license files); the
+open-source engine contains no license checks or telemetry, ever.
+
+## Liability
+
+Any warranty or IP indemnification provided under a commercial license is
+**capped at the fees paid in the trailing twelve months** and **excludes
+third-party data and upstream components** (JPL ephemerides, VSOP87, ELP2000,
+Hipparcos/CDS, ERFA, IAU-CSN). XALEN retains sole control of the defense and
+settlement of indemnified claims. This page is indicative; the **signed
+commercial agreement** is the binding instrument.
+
 ## Contact
 
 For commercial licensing inquiries:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,8 +70,7 @@ sublicense the contribution under both the Apache-2.0 and the commercial
 license. You keep the copyright in your contribution; the CLA only grants the
 licensing rights the dual-license model requires.
 
-<!-- TODO(legal): Insert the full CLA text here — or link the signing flow (e.g.
-     a CLA-assistant bot that records agreement on each PR) — reviewed by
-     counsel, before accepting outside contributions. Until this lands, PRs from
-     new external contributors must be flagged for manual CLA handling and must
-     not be merged. -->
+The full CLA text is in **[CLA.md](CLA.md)**, together with the signing flow:
+post the signing comment from [CLA.md §6](CLA.md) on your first pull request,
+and a maintainer records it before merge. Pull requests from external
+contributors who have not signed the CLA **must not be merged**.

--- a/ENTERPRISE.md
+++ b/ENTERPRISE.md
@@ -35,6 +35,9 @@ to it.
 - High-throughput batch & bulk computation.
 - White-label and on-premise deployment support.
 - Advanced and custom predictive modules built to your specification.
+- **Premium modules** — the Premium Charts pack, Interpretation Content packs,
+  and Precision Data pack, delivered privately under a signed commercial
+  license (see [COMMERCIAL_LICENSE.md](COMMERCIAL_LICENSE.md)).
 
 ---
 

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,36 @@
+# XALEN Trademark Policy
+
+"XALEN", "XALEN Ephemeris", and the XALEN logo are trademarks of
+**XALEN Technology Pvt Ltd** (applications filed in India and other
+jurisdictions, classes 9 and 42). The Apache-2.0 license that covers this
+repository's code expressly does **not** grant trademark rights (Apache-2.0,
+Section 6).
+
+The code is free forever. The name is not — the mark is how users tell the
+validated upstream project apart from forks and modified redistributions.
+
+## Permitted without asking (nominative fair use)
+
+- Truthful, descriptive statements: "built with XALEN Ephemeris",
+  "uses the XALEN Ephemeris engine", "compatible with XALEN 0.6".
+- Referring to the project by name in articles, talks, benchmarks, package
+  metadata, and dependency lists.
+- Unmodified redistribution of the crates/packages under their existing names,
+  as the Apache-2.0 NOTICE terms already require.
+
+## Requires a written license from XALEN Technology Pvt Ltd
+
+- Using "XALEN" (or a confusingly similar name) in the **name of your product,
+  service, company, domain, or package** — e.g. "XalenCloud", "xalen-pro-api".
+- Using the XALEN **logo**.
+- Any statement implying **endorsement, certification, or accuracy validation**
+  by XALEN — including "XALEN Certified", "XALEN Validated", or
+  "XALEN-accurate". These are reserved for the paid validation programme,
+  which requires passing the published test-vector suite and holding a current
+  license.
+- Using the mark on a **modified fork** in a way that suggests it is the
+  upstream project. Forks are welcome under Apache-2.0 — under their own name.
+
+## Contact
+
+Trademark and validation-programme licensing: **hello@xalen.io**

--- a/validation/src/de440_bench.rs
+++ b/validation/src/de440_bench.rs
@@ -217,7 +217,10 @@ fn main() {
             "metric      : |Δ apparent geocentric ecliptic longitude| (DE440 − VSOP87), arcsec"
         );
     } else {
-        println!("reference   : SELF-BASELINE (no kernel found at {})", cfg.kernel);
+        println!(
+            "reference   : SELF-BASELINE (no kernel found at {})",
+            cfg.kernel
+        );
         println!("candidate   : XALEN analytic VSOP87/ELP series (vs itself)");
         println!(
             "metric      : |Δ longitude| — ~0 by construction; this is a wiring check, NOT a validation"
@@ -247,7 +250,9 @@ fn main() {
     println!();
 
     // Sweep.
-    let mut devs: Vec<Deviation> = (0..BENCH_BODIES.len()).map(|_| Deviation::default()).collect();
+    let mut devs: Vec<Deviation> = (0..BENCH_BODIES.len())
+        .map(|_| Deviation::default())
+        .collect();
     let mut skipped: u64 = 0;
     for &jd in &epochs {
         let jd_ut1 = JdUT1(jd);


### PR DESCRIPTION
## What

- **Reproducible DE440 benchmark** (`validation/de440_bench.rs` + `BENCHMARK.md`): measures XALEN vs the real JPL DE440 kernel so the README's precision figures are independently re-runnable.
- **TRADEMARK.md**: trademark/nominative-use policy (wordmark applications are being filed).
- **CLA.md** + CONTRIBUTING.md: full Contributor License Agreement with an interim PR-comment signing flow — resolves the `TODO(legal)` and protects the dual-license model before any external merge.
- **COMMERCIAL_LICENSE.md**: adds the premium-module catalog (Premium Charts, Interpretation Content packs, Precision Data pack, Validation programme) and a liability section (trailing-12-month cap, third-party carve-outs, signed-agreement-controls).
- **ENTERPRISE.md**: references the premium modules.

## Why

Monetization hardening: the open-source engine stays fully Apache-2.0 and data/telemetry-free; paid value is packaged as private premium modules, assurance, and the validated mark. No open-source capability is removed or restricted.

## Checks

- `cargo fmt --all --check` clean, `cargo clippy --workspace --exclude xalen-python -- -D warnings` clean, `cargo test --workspace --exclude xalen-python` green (58 suites) locally.