### PR TITLE
docs: document issue to PR workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ## Related issue
 
-<!-- e.g. Closes #123 -->
+Closes #
 
 ## Type of change
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,14 @@ astrological computation library; correctness and accuracy are the priorities.
 - Rust **1.85+** (edition 2024). Pinned MSRV: `rust-version = "1.85"`.
 - `rustup component add clippy rustfmt`
 
+## Workflow
+
+1. Open a new issue or pick up an existing one before starting work.
+2. Create a focused branch for that issue.
+3. Implement the change together with any needed tests or docs updates.
+4. Run the pre-PR checks below locally.
+5. Open the PR with a closing reference such as `Closes #123`.
+
 ## Before opening a PR
 
 ```bash


### PR DESCRIPTION
Adds a short contribution workflow section and makes the closing issue reference explicit in the PR template.

Closes #15