### PR TITLE
fix: D24 chaturvimsamsa counts forward from Cancer in even signs

### DIFF
--- a/crates/xalen-vedic/src/divisional.rs
+++ b/crates/xalen-vedic/src/divisional.rs
@@ -226,22 +226,19 @@ fn vimsamsa(sign_idx: usize, deg: f64) -> Rashi {
     Rashi::from_index((start + part) % 12)
 }
 
-/// D24 (Chaturvimsamsa / Siddhamsa) per BPHS:
+/// D24 (Chaturvimsamsa / Siddhamsa) per BPHS ch. 6 (Shodasavarga):
 /// Odd signs: sequential from Leo (4)
-/// Even signs: reverse from Cancer (3) — Cancer, Gemini, Taurus, Aries, Pisces...
+/// Even signs: sequential from Cancer (3) — Cancer, Leo, Virgo, Libra, Scorpio...
 /// Each part = 30/24 = 1.25°
+///
+/// BPHS gives the *starting sign* for each parity — Leo for odd, Cancer for
+/// even — and the 24 divisions run FORWARD from that start in both cases. The
+/// parity changes where the count begins, not which direction it travels.
 fn chaturvimsamsa(sign_idx: usize, deg: f64) -> Rashi {
     let is_odd_sign = sign_idx.is_multiple_of(2); // 0-indexed: Aries=0=even idx=odd sign
     let part = (deg / 1.25) as usize;
-    if is_odd_sign {
-        // Odd signs: forward from Leo
-        Rashi::from_index((4 + part) % 12)
-    } else {
-        // Even signs: backward from Cancer
-        // Cancer=3, going backward. Use modular arithmetic to avoid overflow:
-        // (3 - part) mod 12, implemented as (3 + 12 - (part % 12)) % 12
-        Rashi::from_index((3 + 12 - (part % 12)) % 12)
-    }
+    let start = if is_odd_sign { 4 } else { 3 }; // Leo : Cancer
+    Rashi::from_index((start + part) % 12)
 }
 
 /// D27 (Bhamsa / Nakshatramsa) per BPHS:
@@ -583,22 +580,46 @@ mod tests {
     }
 
     #[test]
-    fn d24_even_sign_starts_cancer_backward() {
-        // 0° Taurus (even sign, idx=1): part 0 → (3 + 12 - 0) % 12 = 3 = Cancer
+    fn d24_even_sign_starts_cancer() {
+        // 0° Taurus (even sign, idx=1): part 0 → (3 + 0) % 12 = 3 = Cancer
         assert_eq!(compute_varga_sign(30.0, VargaChart::D24), Rashi::Karka);
         // 0° Cancer (even sign, idx=3): part 0 → Cancer
         assert_eq!(compute_varga_sign(90.0, VargaChart::D24), Rashi::Karka);
     }
 
     #[test]
-    fn d24_even_sign_backward_sequence() {
-        // In Taurus (even sign): 1.25° per part, backward from Cancer
-        // Part 0 = Cancer, Part 1 = Gemini, Part 2 = Taurus, Part 3 = Aries
+    fn d24_even_sign_forward_sequence() {
+        // In Taurus (even sign): 1.25° per part, FORWARD from Cancer.
+        // Part 0 = Cancer, Part 1 = Leo, Part 2 = Virgo, Part 3 = Libra, Part 4 = Scorpio
         assert_eq!(compute_varga_sign(30.0, VargaChart::D24), Rashi::Karka); // Part 0
-        assert_eq!(compute_varga_sign(31.3, VargaChart::D24), Rashi::Mithuna); // Part 1
-        assert_eq!(compute_varga_sign(32.6, VargaChart::D24), Rashi::Vrishabha); // Part 2
-        assert_eq!(compute_varga_sign(33.9, VargaChart::D24), Rashi::Mesha); // Part 3
-        assert_eq!(compute_varga_sign(35.1, VargaChart::D24), Rashi::Meena); // Part 4 (wraps)
+        assert_eq!(compute_varga_sign(31.3, VargaChart::D24), Rashi::Simha); // Part 1
+        assert_eq!(compute_varga_sign(32.6, VargaChart::D24), Rashi::Kanya); // Part 2
+        assert_eq!(compute_varga_sign(33.9, VargaChart::D24), Rashi::Tula); // Part 3
+        assert_eq!(compute_varga_sign(35.1, VargaChart::D24), Rashi::Vrishchika); // Part 4
+    }
+
+    /// Regression test against an independent reference chart.
+    ///
+    /// Birth: 19 May 1983, 03:45 IST, New Delhi (28.6139N, 77.2090E).
+    /// Sidereal positions (Lahiri ayanamsa 23.6197°) and the expected D24
+    /// placements come from third-party Vedic astrology software, not from
+    /// this crate.
+    ///
+    /// All three planets below sit in EVEN signs, which is the branch this
+    /// test guards. Before the forward/backward correction each was displaced
+    /// by exactly `2 * part` signs — 6, 2 and 8 respectively — which is the
+    /// signature of counting the divisions in the wrong direction.
+    #[test]
+    fn d24_even_sign_matches_reference_chart() {
+        // Sun at Taurus 3.7794° → part 3 → Cancer + 3 = Libra
+        assert_eq!(compute_varga_sign(33.7794, VargaChart::D24), Rashi::Tula);
+        // Moon at Cancer 24.9529° → part 19 → Cancer + 19 = Aquarius
+        assert_eq!(compute_varga_sign(114.9529, VargaChart::D24), Rashi::Kumbha);
+        // Jupiter at Scorpio 13.5741° → part 10 → Cancer + 10 = Taurus
+        assert_eq!(
+            compute_varga_sign(223.5741, VargaChart::D24),
+            Rashi::Vrishabha
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`chaturvimsamsa()` (D24 / Siddhamsa) counts the 24 divisions **forward from Leo** for odd signs, which is correct, but **backward from Cancer** for even signs. BPHS ch. 6 gives the *starting sign* for each parity — Leo for odd, Cancer for even — and the divisions run forward from that start in both cases. Parity changes where the count begins, not which direction it travels.

The consequence is that any planet in an even sign is displaced by exactly `2 × part` signs, where `part = floor(deg_in_sign / 1.25)`.

This is easy to miss in spot checks, which may be why it has survived:

- **Odd-sign planets are unaffected** — that branch is correct.
- **Even-sign planets at part 6, 12 or 18 agree by coincidence**, since `2 × 6 = 12 ≡ 0 (mod 12)`.

So a given chart can look mostly right while several placements are wrong, each by a different amount.

The rustdoc also described the reverse ordering as BPHS doctrine, and two tests asserted it. Both are corrected here.

## Related issue

None — reporting and fixing together.

## Type of change

- [x] Bug fix
- [ ] New feature / tradition / house system
- [x] Accuracy / correctness fix
- [ ] Documentation
- [ ] Performance
- [ ] Refactor / internal

## Checklist

- [x] `cargo test --workspace --exclude xalen-python` passes — 856 tests, 0 failures
- [x] `cargo clippy --workspace --exclude xalen-python -- -D warnings` is clean
- [x] `cargo fmt --all --check` is clean
- [x] New or changed behaviour has tests
- [x] For any astronomy/astrology math: cross-validated against an authoritative reference — see below
- [x] Docs updated (rustdoc corrected; `ACCURACY.md` / README not affected — this is a classical-rule fix, not an ephemeris-accuracy claim)
- [x] **No accuracy overclaims** — no claim of matching or beating any reference ephemeris is added

## Accuracy / reference notes

**Validated against an independent third-party reference chart**, not against this crate.

Birth data: **19 May 1983, 03:45 IST, New Delhi (28.6139°N, 77.2090°E)**, Lahiri ayanamsa 23.6197°.

| Planet | D1 position | part | D24 before | D24 after | Reference | Displacement |
|---|---|---|---|---|---|---|
| Sun | Taurus 3.7794° | 3 | Aries | **Libra** | Libra | 6 signs |
| Moon | Cancer 24.9529° | 19 | Sagittarius | **Aquarius** | Aquarius | 2 signs |
| Jupiter | Scorpio 13.5741° | 10 | Virgo | **Taurus** | Taurus | 8 signs |

Each displacement is exactly `2 × part`, which is the signature of counting in the wrong direction. All three now agree with the reference. Committed as `d24_even_sign_matches_reference_chart`.

**Scope check — the other 15 vargas are unaffected.** Before submitting, all sixteen divisional charts were swept across the full zodiac at 0.05° resolution (7,200 samples each) and compared against independently written classical implementations, then cross-checked against PyJHora's default "Traditional Parasara" arithmetic. **D24 was the only divergence** — 3,000 of 7,200 sampled longitudes mismatched, precisely the even-sign spans. D1, D2, D3, D4, D7, D9, D10, D12, D16, D20, D27, D30, D40, D45 and D60 all agreed everywhere, including D30's asymmetric 5/5/8/7/5 boundaries.

**One nuance worth stating plainly:** PyJHora exposes a backward D24 variant under an explicit `chart_method=2` option, so this ordering is not unheard of. But PyJHora's own default is forward, as are the other references consulted, and the existing rustdoc presented the backward count as plain BPHS rather than as a selected variant. That is the basis for treating it as unintentional rather than a deliberate scheme choice. If the reverse ordering *was* deliberate, the right shape is probably an opt-in variant alongside a forward default — happy to rework it that way instead.
