### PR TITLE
fix(node): run explicit Node test files

### DIFF
--- a/crates/xalen-node/package.json
+++ b/crates/xalen-node/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "test": "node --test __test__/"
+    "test": "node --test __test__/smoke.test.mjs __test__/platform-matrix.test.mjs"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.0.0"


### PR DESCRIPTION
## Summary

Updates the Node package test script to explicitly run the two supported Node test files.

## Related issue

<!-- e.g. Closes #123 -->

## Type of change

- Replaces the directory-based Node test invocation with explicit test file paths.
- Keeps the existing test files unchanged.

## Checklist

- [ ] `cargo test --workspace --exclude xalen-python` passes
- [ ] `cargo clippy --workspace --exclude xalen-python -- -D warnings` is clean
- [ ] `cargo fmt --all --check` is clean
- [ ] New or changed behaviour has tests
- [ ] For any astronomy/astrology math: cross-validated against an authoritative reference (Swiss Ephemeris, JPL DE440, IAU SOFA, or the cited classical text) with the measured error stated
- [ ] Docs updated (rustdoc + `ACCURACY.md` / README where relevant)
- [ ] **No accuracy overclaims** — every "matches X" / "accurate to Y" claim is backed by a committed test. The project's rule is that XALEN **matches** reference ephemerides, never claims to **beat** them.

## Accuracy / reference notes

- `npm test` passes successfully.
- 10/10 tests passed.
